### PR TITLE
Added ability to escape query parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "php": ">=5.4.0",
     "ext-mysqlnd": "*",
     "react/promise": "^2.2",
-    "react/event-loop": "dev-master"
+    "react/event-loop": "^0.4.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -136,7 +136,7 @@ class Client
      */
     public function escape(\mysqli $conn, $query, array $params = []) {
         $filtered_params = array_map(function ($value) use ($conn) {
-            return $conn->real_escape_string($value);
+            return '"' . $conn->real_escape_string($value) . '"';
         }, $params);
 
         return str_replace(array_keys($filtered_params), array_values($filtered_params), $query);


### PR DESCRIPTION
MySQLi does not support async prepared statements and to use ->real_escape_string you need access to the connection which you do not have until the query is executed. So I've added a simple escape function and it isn't the best but works.